### PR TITLE
switch to ubi8 base images

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,7 @@
-FROM golang:1.13.1 AS builder
-WORKDIR /src
+FROM registry.access.redhat.com/ubi8/go-toolset:1.13.15 AS builder
 COPY . .
-RUN go mod download
 RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -o out/s3-reload s3-reload.go
 
-FROM alpine:3.8
-RUN apk --no-cache add ca-certificates
-USER 65534
-COPY --from=builder /src/out/s3-reload /s3-reload
+FROM registry.access.redhat.com/ubi8/ubi-minimal:8.2
+COPY --from=builder /opt/app-root/src/out/s3-reload /s3-reload
 ENTRYPOINT ["/s3-reload"]


### PR DESCRIPTION
Also changed:
- removed unnecessary `go mod download` in the builder image
- ca-certificates is already installed in UBI
- removed `USER` directive in app image as openshift will run as a random UID anyway