### PR TITLE
Prepare s3-reload for CI migration

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,8 @@
 FROM registry.access.redhat.com/ubi9/go-toolset:1.22.9 AS builder
 COPY . .
 RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -o out/s3-reload s3-reload.go
+LABEL konflux.additional-tags="1.0.0"
 
-FROM registry.access.redhat.com/ubi8/ubi-minimal:8.2
+FROM registry.access.redhat.com/ubi9-minimal:9.5
 COPY --from=builder /opt/app-root/src/out/s3-reload /s3-reload
 ENTRYPOINT ["/s3-reload"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi8/go-toolset:1.13.15 AS builder
+FROM registry.access.redhat.com/ubi9/go-toolset:1.22.9 AS builder
 COPY . .
 RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -o out/s3-reload s3-reload.go
 


### PR DESCRIPTION
This MR updates base images for s3-reload to ubi9 image sources, in addition to adding a konflux tags for CI migration.